### PR TITLE
Temporal Resolution Change for vWii option - enhancement (HDMI only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ ifdef DISPLAY
     CFLAGS += -DDISPLAY=$(DISPLAY)
 endif
 
+ifdef FORCERES
+    CFLAGS += -DFORCERES=$(FORCERES)
+endif
+
+
 #-------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level
 # containing include and lib

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Just specify them as compile time options after `make`! Supported parameters are
   ConnectMii channel)
 * `DISPLAY`: Display mode of the booted vWii channel. Supported modes are: `TV`, `DRC` (GamePad) or `BOTH` (defaults
   to `BOTH`). Note that it falls back to the GamePad if no TV is connected.
+* `FORCERES`: Forces resolution when booting a vWii channel. Supported modes are: `NONE`, `P720` or `P480` (defaults
+  to `NONE`). Note that it only works with HDMI.
 
 ### Examples
 

--- a/source/main.c
+++ b/source/main.c
@@ -26,7 +26,7 @@ enum SCREEN_TYPE {
     BOTH = 3
 };
 
-enum FORCE_RES {
+enum FORCERES {
     NONE = 0,
     P720 = 4,
     P480 = 3

--- a/source/main.c
+++ b/source/main.c
@@ -16,11 +16,49 @@
 #define DISPLAY BOTH
 #endif
 
+#ifndef FORCERES
+#define FORCERES NONE
+#endif
+
 enum SCREEN_TYPE {
     TV = 1,
     DRC = 2,
     BOTH = 3
 };
+
+enum FORCE_RES {
+    NONE = 0,
+    P720 = 4,
+    P480 = 3
+};
+
+extern int (OSDynLoad_Acquire)(const char* rpl, uint32_t *handle);
+
+extern int (OSDynLoad_FindExport)(uint32_t handle, int isdata, const char *symbol, void *address);
+
+void SwitchVideoMode() {
+		
+    unsigned int avm_handle;
+    OSDynLoad_Acquire("avm.rpl", & avm_handle);
+    int( * AVMSetTVScanResolution)(int r3);
+    int( * AVMGetCurrentPort)(int * port);
+
+    OSDynLoad_FindExport(avm_handle, 0, "AVMSetTVScanResolution", & AVMSetTVScanResolution);
+    OSDynLoad_FindExport(avm_handle, 0, "AVMGetCurrentPort", & AVMGetCurrentPort);
+
+    // out port shouldn't be needed, dont use if scart/composite or component
+    int outPort = 0;
+    AVMGetCurrentPort( & outPort);
+    if (outPort > 3) outPort = 0;
+    int wantRes = FORCERES;
+
+    if (outPort == 2 || outPort == 3) {
+        return;
+    } else {
+        AVMSetTVScanResolution(wantRes);
+    }
+
+}
 
 extern int CMPTLaunchTitle(void *CMPTConfigure, int ConfigSize, int titlehigh, int titlelow);
 
@@ -49,6 +87,10 @@ int main(int argc, char **argv) {
     }
 
     KPADInit();
+	
+	if (FORCERES != NONE) {
+	SwitchVideoMode();
+	}
 
     void *databuf = memalign(0x40, dataSize);
     CMPTLaunchTitle(databuf, dataSize, TIDHIGH, TIDLOW);


### PR DESCRIPTION
The code change doesn't seem to break anything on my tests and it correctly sets the resolution at 720p and 480p which maximizes the Wii Mode video quality for me since my TV better handles the 480p signal and upscales it instead of 1080p (which is actually bad for the vWii's video quality but good for Wii U's video quality) 

_Credits probably go to [Fix94](https://github.com/FIX94)_ since [mive](https://gbatemp.net/members/mive.457567/) used part of Fix94's [code](https://github.com/FIX94/wiiu-video-mode-changer) on [hbl2hbc mod](https://gbatemp.net/threads/hbl2hbc-v1-1-boot-from-wiiu-hbl-into-vwii-hbc.455673/page-11#post-9059814) which eventually was also used by [killerpommes](https://github.com/killerpommes) for it to be merged [here](https://github.com/killerpommes/Boot2vWii/tree/patch-1).